### PR TITLE
Augment test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/node_modules
+node_modules
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
-node_js:
-  - "0.12"
-  - "0.10"
-  - "iojs"
 sudo: false
+notifications:
+  email: false
+node_js:
+  - "10" # stable
+  - "8" # LTS
+  - "6" # maintenance
 cache:
   directories:
     - node_modules
-notifications:
-  email: false

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,7 +15,8 @@ module.exports = function (grunt) {
     release: {
       options: {
         tagName: 'v<%= version %>',
-        commitMessage: 'Prepared to release <%= version %>.'
+        commitMessage: 'Prepared to release <%= version %>.',
+        additionalFiles: ['package-lock.json']
       }
     },
     watch: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha1-5fHzkoxtlf2WVYw27D2dDeSm7Oo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.6",
         "negotiator": "0.5.3"
       },
       "dependencies": {
@@ -32,7 +32,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         }
       }
@@ -55,8 +55,8 @@
       "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
       "dev": true,
       "requires": {
-        "underscore": "1.7.0",
-        "underscore.string": "2.4.0"
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
       },
       "dependencies": {
         "underscore.string": {
@@ -115,10 +115,10 @@
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "dev": true,
       "requires": {
-        "continuable-cache": "0.3.1",
-        "error": "7.0.2",
-        "raw-body": "1.1.7",
-        "safe-json-parse": "1.0.1"
+        "continuable-cache": "^0.3.1",
+        "error": "^7.0.0",
+        "raw-body": "~1.1.0",
+        "safe-json-parse": "~1.0.1"
       },
       "dependencies": {
         "bytes": {
@@ -133,8 +133,8 @@
           "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
           "dev": true,
           "requires": {
-            "bytes": "1.0.0",
-            "string_decoder": "0.10.31"
+            "bytes": "1",
+            "string_decoder": "0.10"
           }
         }
       }
@@ -146,15 +146,15 @@
       "dev": true,
       "requires": {
         "bytes": "2.1.0",
-        "content-type": "1.0.4",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "http-errors": "1.3.1",
+        "content-type": "~1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "http-errors": "~1.3.1",
         "iconv-lite": "0.4.11",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "4.0.0",
-        "raw-body": "2.1.7",
-        "type-is": "1.6.16"
+        "raw-body": "~2.1.2",
+        "type-is": "~1.6.6"
       },
       "dependencies": {
         "debug": {
@@ -190,7 +190,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "ms": {
@@ -221,7 +221,7 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.18"
+            "mime-types": "~2.1.18"
           }
         }
       }
@@ -232,7 +232,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -258,12 +258,18 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
+    },
+    "ci-info": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
+      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "dev": true
     },
     "cline": {
       "version": "0.8.2",
@@ -310,7 +316,7 @@
       "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
       "dev": true,
       "requires": {
-        "mime-db": "1.34.0"
+        "mime-db": ">= 1.33.0 < 2"
       },
       "dependencies": {
         "mime-db": {
@@ -327,12 +333,12 @@
       "integrity": "sha1-sDuNhub4rSloPLqN+R3cb/x3s5U=",
       "dev": true,
       "requires": {
-        "accepts": "1.2.13",
+        "accepts": "~1.2.12",
         "bytes": "2.1.0",
-        "compressible": "2.0.13",
-        "debug": "2.2.0",
-        "on-headers": "1.0.1",
-        "vary": "1.0.1"
+        "compressible": "~2.0.5",
+        "debug": "~2.2.0",
+        "on-headers": "~1.0.0",
+        "vary": "~1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -365,36 +371,36 @@
       "dev": true,
       "requires": {
         "basic-auth-connect": "1.0.0",
-        "body-parser": "1.13.3",
+        "body-parser": "~1.13.3",
         "bytes": "2.1.0",
-        "compression": "1.5.2",
-        "connect-timeout": "1.6.2",
-        "content-type": "1.0.4",
+        "compression": "~1.5.2",
+        "connect-timeout": "~1.6.2",
+        "content-type": "~1.0.1",
         "cookie": "0.1.3",
-        "cookie-parser": "1.3.5",
+        "cookie-parser": "~1.3.5",
         "cookie-signature": "1.0.6",
-        "csurf": "1.8.3",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "errorhandler": "1.4.3",
-        "express-session": "1.11.3",
+        "csurf": "~1.8.3",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "errorhandler": "~1.4.2",
+        "express-session": "~1.11.3",
         "finalhandler": "0.4.0",
         "fresh": "0.3.0",
-        "http-errors": "1.3.1",
-        "method-override": "2.3.10",
-        "morgan": "1.6.1",
+        "http-errors": "~1.3.1",
+        "method-override": "~2.3.5",
+        "morgan": "~1.6.1",
         "multiparty": "3.3.2",
-        "on-headers": "1.0.1",
-        "parseurl": "1.3.2",
+        "on-headers": "~1.0.0",
+        "parseurl": "~1.3.0",
         "pause": "0.1.0",
         "qs": "4.0.0",
-        "response-time": "2.3.2",
-        "serve-favicon": "2.3.2",
-        "serve-index": "1.7.3",
-        "serve-static": "1.10.3",
-        "type-is": "1.6.16",
+        "response-time": "~2.3.1",
+        "serve-favicon": "~2.3.0",
+        "serve-index": "~1.7.2",
+        "serve-static": "~1.10.0",
+        "type-is": "~1.6.6",
         "utils-merge": "1.0.0",
-        "vhost": "3.0.2"
+        "vhost": "~3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -418,7 +424,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "ms": {
@@ -440,7 +446,7 @@
           "dev": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.18"
+            "mime-types": "~2.1.18"
           }
         }
       }
@@ -451,10 +457,10 @@
       "integrity": "sha1-L6vs/cGop3S6GUhNzmYMgYqFVec=",
       "dev": true,
       "requires": {
-        "multiparty": "3.3.2",
-        "on-finished": "2.1.1",
-        "qs": "2.2.5",
-        "type-is": "1.5.7"
+        "multiparty": "~3.3.2",
+        "on-finished": "~2.1.0",
+        "qs": "~2.2.4",
+        "type-is": "~1.5.2"
       },
       "dependencies": {
         "qs": {
@@ -471,10 +477,10 @@
       "integrity": "sha1-3ppexh4zoStu2qt7XwYumMWZuI4=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "http-errors": "1.3.1",
+        "debug": "~2.2.0",
+        "http-errors": "~1.3.1",
         "ms": "0.7.1",
-        "on-headers": "1.0.1"
+        "on-headers": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -571,8 +577,8 @@
       "requires": {
         "cookie": "0.1.3",
         "cookie-signature": "1.0.6",
-        "csrf": "3.0.6",
-        "http-errors": "1.3.1"
+        "csrf": "~3.0.0",
+        "http-errors": "~1.3.1"
       }
     },
     "dateformat": {
@@ -635,8 +641,8 @@
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "dev": true,
       "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
+        "string-template": "~0.2.1",
+        "xtend": "~4.0.0"
       }
     },
     "errorhandler": {
@@ -645,8 +651,8 @@
       "integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
-        "escape-html": "1.0.3"
+        "accepts": "~1.3.0",
+        "escape-html": "~1.0.3"
       },
       "dependencies": {
         "accepts": {
@@ -655,7 +661,7 @@
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "dev": true,
           "requires": {
-            "mime-types": "2.1.18",
+            "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -677,7 +683,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "negotiator": {
@@ -730,27 +736,27 @@
       "integrity": "sha1-DCkD7lxU5j1lqWFwdkcDVQZlo94=",
       "dev": true,
       "requires": {
-        "basic-auth": "1.0.4",
+        "basic-auth": "~1.0.3",
         "commander": "2.6.0",
         "connect": "2.30.2",
         "content-disposition": "0.5.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.1",
         "cookie": "0.1.3",
         "cookie-signature": "1.0.6",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
         "escape-html": "1.0.2",
-        "etag": "1.7.0",
+        "etag": "~1.7.0",
         "fresh": "0.3.0",
         "merge-descriptors": "1.0.0",
-        "methods": "1.1.2",
+        "methods": "~1.1.1",
         "mkdirp": "0.5.1",
-        "parseurl": "1.3.2",
-        "proxy-addr": "1.0.10",
-        "range-parser": "1.0.3",
+        "parseurl": "~1.3.0",
+        "proxy-addr": "~1.0.8",
+        "range-parser": "~1.0.2",
         "send": "0.13.0",
         "utils-merge": "1.0.0",
-        "vary": "1.0.1"
+        "vary": "~1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -785,11 +791,11 @@
         "cookie": "0.1.3",
         "cookie-signature": "1.0.6",
         "crc": "3.3.0",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "on-headers": "1.0.1",
-        "parseurl": "1.3.2",
-        "uid-safe": "2.0.0",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "on-headers": "~1.0.0",
+        "parseurl": "~1.3.0",
+        "uid-safe": "~2.0.0",
         "utils-merge": "1.0.0"
       },
       "dependencies": {
@@ -831,7 +837,7 @@
       "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
       "dev": true,
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "finalhandler": {
@@ -840,10 +846,10 @@
       "integrity": "sha1-llpS2ejQXSuFdUhUH7ibU6JJfZs=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
+        "debug": "~2.2.0",
         "escape-html": "1.0.2",
-        "on-finished": "2.3.0",
-        "unpipe": "1.0.0"
+        "on-finished": "~2.3.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -884,8 +890,8 @@
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2"
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "glob": {
@@ -894,8 +900,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "lodash": {
@@ -910,8 +916,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -922,9 +928,9 @@
       "integrity": "sha1-TuQ0bm61Ni6DRKAgdb2NvYxzc+o=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "combined-stream": "0.0.7",
-        "mime": "1.2.11"
+        "async": "~0.9.0",
+        "combined-stream": "~0.0.4",
+        "mime": "~1.2.11"
       },
       "dependencies": {
         "async": {
@@ -941,7 +947,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "formidable": {
@@ -974,7 +980,7 @@
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.1"
+        "globule": "^1.0.0"
       },
       "dependencies": {
         "glob": {
@@ -983,12 +989,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globule": {
@@ -997,9 +1003,9 @@
           "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.10",
+            "minimatch": "~3.0.2"
           }
         },
         "lodash": {
@@ -1014,7 +1020,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -1031,9 +1037,9 @@
       "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
       "dev": true,
       "requires": {
-        "graceful-fs": "1.2.3",
-        "inherits": "1.0.2",
-        "minimatch": "0.2.14"
+        "graceful-fs": "~1.2.0",
+        "inherits": "1",
+        "minimatch": "~0.2.11"
       },
       "dependencies": {
         "inherits": {
@@ -1050,9 +1056,9 @@
       "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
       "dev": true,
       "requires": {
-        "glob": "3.1.21",
-        "lodash": "1.0.2",
-        "minimatch": "0.2.14"
+        "glob": "~3.1.21",
+        "lodash": "~1.0.1",
+        "minimatch": "~0.2.11"
       },
       "dependencies": {
         "lodash": {
@@ -1081,26 +1087,26 @@
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "coffee-script": "1.3.3",
-        "colors": "0.6.2",
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
         "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.1.3",
-        "getobject": "0.1.0",
-        "glob": "3.1.21",
-        "grunt-legacy-log": "0.1.3",
-        "grunt-legacy-util": "0.2.0",
-        "hooker": "0.2.3",
-        "iconv-lite": "0.2.11",
-        "js-yaml": "2.0.5",
-        "lodash": "0.9.2",
-        "minimatch": "0.2.14",
-        "nopt": "1.0.10",
-        "rimraf": "2.2.8",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       },
       "dependencies": {
         "coffee-script": {
@@ -1117,9 +1123,9 @@
       "integrity": "sha1-6evEBHYx9QEtkidww5N4EzytEPQ=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.1.3",
-        "nopt": "1.0.10",
-        "resolve": "0.3.1"
+        "findup-sync": "~0.1.0",
+        "nopt": "~1.0.10",
+        "resolve": "~0.3.1"
       }
     },
     "grunt-contrib-watch": {
@@ -1128,10 +1134,10 @@
       "integrity": "sha512-yGweN+0DW5yM+oo58fRu/XIRrPcn3r4tQx+nL7eMRwjpvk+rQY6R8o94BPK0i2UhTg9FN21hS+m8vR8v9vXfeg==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "gaze": "1.1.3",
-        "lodash": "4.17.10",
-        "tiny-lr": "1.1.1"
+        "async": "^2.6.0",
+        "gaze": "^1.1.0",
+        "lodash": "^4.17.10",
+        "tiny-lr": "^1.1.1"
       },
       "dependencies": {
         "async": {
@@ -1140,7 +1146,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.17.10"
           }
         },
         "lodash": {
@@ -1157,11 +1163,11 @@
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "grunt-legacy-log-utils": "0.1.1",
-        "hooker": "0.2.3",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "lodash": {
@@ -1184,9 +1190,9 @@
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "lodash": {
@@ -1209,13 +1215,13 @@
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "0.9.2",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       }
     },
     "grunt-mocha-test": {
@@ -1224,8 +1230,8 @@
       "integrity": "sha1-xhzfMqZ2KVQRX+cSuYPj3Y4MlVQ=",
       "dev": true,
       "requires": {
-        "hooker": "0.2.3",
-        "mkdirp": "0.5.1"
+        "hooker": "~0.2.3",
+        "mkdirp": "^0.5.0"
       }
     },
     "grunt-release": {
@@ -1234,10 +1240,10 @@
       "integrity": "sha1-Wwal8wDWYqM9UqL74he9gMg4P8o=",
       "dev": true,
       "requires": {
-        "q": "1.5.1",
-        "semver": "4.3.6",
-        "shelljs": "0.3.0",
-        "superagent": "0.21.0"
+        "q": "^1.1.2",
+        "semver": "^4.1.0",
+        "shelljs": "^0.3.0",
+        "superagent": "^0.21.0"
       }
     },
     "has-ansi": {
@@ -1246,7 +1252,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "hooker": {
@@ -1261,8 +1267,8 @@
       "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "statuses": "1.5.0"
+        "inherits": "~2.0.1",
+        "statuses": "1"
       }
     },
     "http-parser-js": {
@@ -1277,12 +1283,12 @@
       "integrity": "sha1-h8Vy0hD7DV+J91YXeuACDUn/ujY=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "chalk": "1.1.3",
-        "cline": "0.8.2",
+        "async": ">=0.1.0 <1.0.0",
+        "chalk": "^1.0.0",
+        "cline": "^0.8.2",
         "coffee-script": "1.6.3",
-        "connect-multiparty": "1.2.5",
-        "express": "3.21.2",
+        "connect-multiparty": "^1.2.5",
+        "express": "^3.21.2",
         "log": "1.4.0",
         "optparse": "1.0.4",
         "scoped-http-client": "0.11.0"
@@ -1294,7 +1300,7 @@
       "integrity": "sha1-4+Szc2koH9dvH7Z4W13HXHloNPY=",
       "dev": true,
       "requires": {
-        "hubot": "3.0.1"
+        "hubot": ">=3.0.0 <10 || 0.0.0-development"
       },
       "dependencies": {
         "hubot": {
@@ -1303,17 +1309,28 @@
           "integrity": "sha512-hTn3pLcS77nyzYWNft5djDM45nWTyH6Ee/wLkSk5NazzMZi0R1wWQK0elAFiAK9u152SJ2x80P4IBK0Z5Gxf5w==",
           "dev": true,
           "requires": {
-            "async": "0.1.22",
-            "chalk": "1.1.3",
-            "cline": "0.8.2",
+            "async": ">=0.1.0 <1.0.0",
+            "chalk": "^1.0.0",
+            "cline": "^0.8.2",
             "coffee-script": "1.6.3",
-            "connect-multiparty": "1.2.5",
-            "express": "3.21.2",
+            "connect-multiparty": "^1.2.5",
+            "express": "^3.21.2",
             "log": "1.4.0",
             "optparse": "1.0.4",
             "scoped-http-client": "0.11.0"
           }
         }
+      }
+    },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "^1.0.10",
+        "normalize-path": "^1.0.0",
+        "strip-indent": "^2.0.0"
       }
     },
     "iconv-lite": {
@@ -1328,8 +1345,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1343,6 +1360,15 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.0.5.tgz",
       "integrity": "sha1-X6eM8wG4JceKvDBC2BJyMEnqI8c=",
       "dev": true
+    },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -1380,8 +1406,8 @@
       "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
       "dev": true,
       "requires": {
-        "argparse": "0.1.16",
-        "esprima": "1.0.4"
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
       }
     },
     "livereload-js": {
@@ -1420,9 +1446,9 @@
       "integrity": "sha1-Qo5knOXCgY0iDgRj7/XA3p5Z1S4=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.1.3",
-        "globule": "0.1.0",
-        "resolve": "0.5.1",
+        "findup-sync": "~0.1.2",
+        "globule": "~0.1.0",
+        "resolve": "~0.5.1",
         "stack-trace": "0.0.7"
       },
       "dependencies": {
@@ -1453,9 +1479,9 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "methods": "1.1.2",
-        "parseurl": "1.3.2",
-        "vary": "1.1.2"
+        "methods": "~1.1.2",
+        "parseurl": "~1.3.2",
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "debug": {
@@ -1505,7 +1531,7 @@
       "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
       "dev": true,
       "requires": {
-        "mime-db": "1.12.0"
+        "mime-db": "~1.12.0"
       }
     },
     "minimatch": {
@@ -1514,8 +1540,8 @@
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -1578,8 +1604,8 @@
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "inherits": "2",
+            "minimatch": "0.3"
           }
         },
         "minimatch": {
@@ -1588,8 +1614,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         },
         "ms": {
@@ -1612,11 +1638,11 @@
       "integrity": "sha1-X9gYOYxoGcuiinzWZk8pL+HAu/I=",
       "dev": true,
       "requires": {
-        "basic-auth": "1.0.4",
-        "debug": "2.2.0",
-        "depd": "1.0.1",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "basic-auth": "~1.0.3",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1663,8 +1689,8 @@
       "integrity": "sha1-Nd5oBNwZZD5SSfPT473GyM4wHT8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
-        "stream-counter": "0.2.0"
+        "readable-stream": "~1.1.9",
+        "stream-counter": "~0.2.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -1673,10 +1699,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -1693,8 +1719,14 @@
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
+    },
+    "normalize-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+      "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1723,7 +1755,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optparse": {
@@ -1756,7 +1788,7 @@
       "integrity": "sha1-DUCoL4Afw1VWfS7LZe/j8HfxIcU=",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.0",
         "ipaddr.js": "1.0.5"
       }
     },
@@ -1815,10 +1847,10 @@
       "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "reduce-component": {
@@ -1839,8 +1871,8 @@
       "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.0",
+        "on-headers": "~1.0.1"
       },
       "dependencies": {
         "depd": {
@@ -1893,18 +1925,18 @@
       "integrity": "sha1-UY+SGusFYK7H3KspkLFM9vPM5d4=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "depd": "1.0.1",
+        "debug": "~2.2.0",
+        "depd": "~1.0.1",
         "destroy": "1.0.3",
         "escape-html": "1.0.2",
-        "etag": "1.7.0",
+        "etag": "~1.7.0",
         "fresh": "0.3.0",
-        "http-errors": "1.3.1",
+        "http-errors": "~1.3.1",
         "mime": "1.3.4",
         "ms": "0.7.1",
-        "on-finished": "2.3.0",
-        "range-parser": "1.0.3",
-        "statuses": "1.2.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.0.2",
+        "statuses": "~1.2.1"
       },
       "dependencies": {
         "debug": {
@@ -1963,10 +1995,10 @@
       "integrity": "sha1-3UGeJo3gEqtysxnTN/IQUBP5OB8=",
       "dev": true,
       "requires": {
-        "etag": "1.7.0",
+        "etag": "~1.7.0",
         "fresh": "0.3.0",
         "ms": "0.7.2",
-        "parseurl": "1.3.2"
+        "parseurl": "~1.3.1"
       },
       "dependencies": {
         "ms": {
@@ -1983,13 +2015,13 @@
       "integrity": "sha1-egV/xu4o3GP2RWbl+lexEahq7NI=",
       "dev": true,
       "requires": {
-        "accepts": "1.2.13",
+        "accepts": "~1.2.13",
         "batch": "0.5.3",
-        "debug": "2.2.0",
-        "escape-html": "1.0.3",
-        "http-errors": "1.3.1",
-        "mime-types": "2.1.18",
-        "parseurl": "1.3.2"
+        "debug": "~2.2.0",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.3.1",
+        "mime-types": "~2.1.9",
+        "parseurl": "~1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -2019,7 +2051,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "ms": {
@@ -2036,8 +2068,8 @@
       "integrity": "sha1-zlpuzTEB/tXsCYJ9rCKpwpv7BTU=",
       "dev": true,
       "requires": {
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.1",
         "send": "0.13.2"
       },
       "dependencies": {
@@ -2095,18 +2127,18 @@
           "integrity": "sha1-dl52B8gFVFK7pvCwUllTUJhgNt4=",
           "dev": true,
           "requires": {
-            "debug": "2.2.0",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "escape-html": "1.0.3",
-            "etag": "1.7.0",
+            "debug": "~2.2.0",
+            "depd": "~1.1.0",
+            "destroy": "~1.0.4",
+            "escape-html": "~1.0.3",
+            "etag": "~1.7.0",
             "fresh": "0.3.0",
-            "http-errors": "1.3.1",
+            "http-errors": "~1.3.1",
             "mime": "1.3.4",
             "ms": "0.7.1",
-            "on-finished": "2.3.0",
-            "range-parser": "1.0.3",
-            "statuses": "1.2.1"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.0.3",
+            "statuses": "~1.2.1"
           }
         },
         "statuses": {
@@ -2138,7 +2170,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.4"
+        "util": ">=0.10.3 <1"
       }
     },
     "sinon-chai": {
@@ -2165,7 +2197,7 @@
       "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.8"
       },
       "dependencies": {
         "readable-stream": {
@@ -2174,10 +2206,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         }
       }
@@ -2200,8 +2232,14 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+      "dev": true
     },
     "superagent": {
       "version": "0.21.0",
@@ -2211,8 +2249,8 @@
       "requires": {
         "component-emitter": "1.1.2",
         "cookiejar": "2.0.1",
-        "debug": "2.6.9",
-        "extend": "1.2.1",
+        "debug": "2",
+        "extend": "~1.2.1",
         "form-data": "0.1.3",
         "formidable": "1.0.14",
         "methods": "1.0.1",
@@ -2251,12 +2289,12 @@
       "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "dev": true,
       "requires": {
-        "body": "5.1.0",
-        "debug": "3.1.0",
-        "faye-websocket": "0.10.0",
-        "livereload-js": "2.3.0",
-        "object-assign": "4.1.1",
-        "qs": "6.5.2"
+        "body": "^5.1.0",
+        "debug": "^3.1.0",
+        "faye-websocket": "~0.10.0",
+        "livereload-js": "^2.3.0",
+        "object-assign": "^4.1.0",
+        "qs": "^6.4.0"
       }
     },
     "to-iso-string": {
@@ -2284,7 +2322,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.0.14"
+        "mime-types": "~2.0.9"
       }
     },
     "uid-safe": {
@@ -2293,7 +2331,7 @@
       "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
       "dev": true,
       "requires": {
-        "random-bytes": "1.0.0"
+        "random-bytes": "~1.0.0"
       }
     },
     "underscore": {
@@ -2347,8 +2385,8 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.13",
-        "websocket-extensions": "0.1.3"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "author": "Brandon Valentine <brandon@brandonvalentine.com>",
   "license": "MIT",
-  "keywords": "security, security-theatre, security-theater",
+  "keywords": "hubot, hubot-scripts, security, security-theatre, security-theater",
   "repository": {
     "type": "git",
     "url": "git://github.com/hubot-scripts/hubot-security-posters.git"
@@ -14,10 +14,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "hubot": "2.x"
+    "hubot": ">=2 <10 || 0.0.0-development"
   },
   "devDependencies": {
-    "hubot-test-helper": "^1.3.0",
     "chai": "^2.1.1",
     "coffee-script": "1.6.3",
     "grunt": "^0.4.5",
@@ -26,6 +25,8 @@
     "grunt-mocha-test": "~0.12.7",
     "grunt-release": "~0.11.0",
     "hubot": "2.x",
+    "hubot-test-helper": "^1.3.0",
+    "husky": "^0.14.3",
     "matchdep": "~0.3.0",
     "mocha": "^2.1.0",
     "sinon": "^1.13.0",
@@ -33,6 +34,8 @@
   },
   "main": "index.coffee",
   "scripts": {
+    "precommit": "npm test",
+    "prepush": "npm test",
     "test": "grunt test"
   }
 }

--- a/test/security-posters-test.coffee
+++ b/test/security-posters-test.coffee
@@ -12,16 +12,6 @@ describe 'security-posters', ->
   afterEach ->
     @room.destroy()
 
-  it 'responds to hello', ->
-    @room.user.say('alice', '@hubot hello').then =>
-      expect(@room.messages).to.eql [
-        ['alice', '@hubot hello']
-        ['hubot', '@alice hello!']
-      ]
-
-  it 'hears orly', ->
-    @room.user.say('bob', 'just wanted to say orly').then =>
-      expect(@room.messages).to.eql [
-        ['bob', 'just wanted to say orly']
-        ['hubot', 'yarly']
-      ]
+  it 'responds with a random poster', ->
+    @room.user.say('alice', '@hubot security').then =>
+      expect(@room.messages[1][1]).to.match /@alice http\:\/\/brandonvalentine.com\/nsa\-security\-posters\/image\-\d+\.png/i


### PR DESCRIPTION
I've been on a mission lately to make Hubot packages a little beefier in the testing department, so this does a very trivial check to make sure that the responder works.

Also:

- Adds extra keywords so it can be found easier on NPM
- Adds the correct versions of Node to test against on Travis CI
- Fixes an issue where the `package-lock.json` doesn't get bumped by Grunt
- Adds some extra things to ignore in the repository
- Adds Husky to automate test running on commit/push